### PR TITLE
Fixes/changes to compatibility wrapper

### DIFF
--- a/ToolkitApi/CW/cw.php
+++ b/ToolkitApi/CW/cw.php
@@ -2266,9 +2266,11 @@ function i5_spool_list($description = array(), $connection = null)
         
         // if outq is not *ALL, it should have a library name
         if (($outq != '*ALL') && empty($outqLibName)) {
+        	// Try *LIBL
+        	$outqLibName = '*LIBL';
             // if no libname, result set will be empty, so might as well alert the user.
-            i5ErrorActivity(I5_ERR_PHP_ELEMENT_MISSING, I5_CAT_PHP, 'Missing outq library', 'You specified an outq but did not qualify it with a library name.');
-            return false;
+            //i5ErrorActivity(I5_ERR_PHP_ELEMENT_MISSING, I5_CAT_PHP, 'Missing outq library', 'You specified an outq but did not qualify it with a library name.');
+           // return false;
         }
     }
     
@@ -2755,7 +2757,8 @@ function listRead(&$list)
         // we simply have no more records to receive.
         $errorCode = $connection->getErrorCode();
         if ($errorCode == '' || $errorCode == 'GUI0006' || $errorCode == 'GUI0001') {
-            i5ErrorActivity(I5_ERR_BEOF, I5_CAT_PHP, 'No more entries.', 'No more entries.');
+        	// EOF is not an error, just clogs the log, completely normal, happens to everyone...
+            //i5ErrorActivity(I5_ERR_BEOF, I5_CAT_PHP, 'No more entries.', 'No more entries.');        	
         } else {
             // a real error.
              i5CpfError($errorCode, $connection->getErrorMsg());

--- a/ToolkitApi/CW/cwclasses.php
+++ b/ToolkitApi/CW/cwclasses.php
@@ -778,8 +778,9 @@ class DataDescription
                 // Look up its value (could be another data structure or a single value)
                 // in the input array, based on data structure name.
                 $dsData = $this->findValueInArray($dsName, $inputValues);
-
-                if (!$dsData) {
+                // Compare with null since this is what findValueInArray returns on error
+                // this will prevent things such as empty arrays from causing errors
+                if ($dsData === null) {
                     // ds has no description to match value!
                     i5ErrorActivity(I5_ERR_PARAMNOTFOUND, I5_CAT_PHP, "Requested parameter '$dsName' does not exist in the input data", "Requested parameter $dsName does not exist in the input data");
                     return false;

--- a/ToolkitApi/CW/cwclasses.php
+++ b/ToolkitApi/CW/cwclasses.php
@@ -585,7 +585,7 @@ class DataDescription
      * and return the value associated with the key name provided.
      * 
      * @param string $searchKey   key to search for
-     * @return string|array|null  value found in input array for array key. null if failed
+     * @return string|array|false  value found in input array for array key. false if failed
      */
     protected function findValueInArray($searchKey, $valueArray)
     {
@@ -594,7 +594,7 @@ class DataDescription
         // ensure that array is not empty
         if (!count($valueArray)) {
              i5ErrorActivity(I5_ERR_PHP_TYPEPARAM, I5_CAT_PHP, "Array of input values must not be empty", "Array of input values must not be empty");
-             return null;
+             return false;
         }
 
         foreach ($valueArray as $key=>$value) {
@@ -608,7 +608,7 @@ class DataDescription
 
         // if failed, return null
         // $connection->logThis("findValueInArray: searchKey: $searchKey. no value found");
-        return null;
+        return false;
     }
     
     /**
@@ -778,9 +778,9 @@ class DataDescription
                 // Look up its value (could be another data structure or a single value)
                 // in the input array, based on data structure name.
                 $dsData = $this->findValueInArray($dsName, $inputValues);
-                // Compare with null since this is what findValueInArray returns on error
+                // Compare with false since this is what findValueInArray returns on error
                 // this will prevent things such as empty arrays from causing errors
-                if ($dsData === null) {
+                if ($dsData === false) {
                     // ds has no description to match value!
                     i5ErrorActivity(I5_ERR_PARAMNOTFOUND, I5_CAT_PHP, "Requested parameter '$dsName' does not exist in the input data", "Requested parameter $dsName does not exist in the input data");
                     return false;


### PR DESCRIPTION
Fixed cwclasses to do a strict comparison to null in oldToNewDescriptionItem since that is what the called function is returning on error, prevents things like empty arrays from causing an error.

Changed two functions in cw.php:
1 - i5_spool_list - do not require an outq library use *LIBL if one is not provided
2 - listRead - remove error logging when no more entries found, just clogs the log.