### PR TITLE
Removed requirement for autoloaded classes to exist in class map. Add…

### DIFF
--- a/ToolkitApi/autoload.php
+++ b/ToolkitApi/autoload.php
@@ -41,11 +41,6 @@ spl_autoload_register(function($class){
         'ToolkitApi\CW\DataDescriptionPcml' => __DIR__ . DIRECTORY_SEPARATOR . 'CW' . DIRECTORY_SEPARATOR . 'DataDescriptionPcml.php',
     );
 
-    if (!array_key_exists($class,$classmap))
-    {
-        throw new Exception("Class $class isn't defined in classmap");
-    }
-
     $file = $classmap[$class];
     if (!is_readable($file)) {
         throw new Exception("File $file Not Found");


### PR DESCRIPTION
…resses #50

Since applications may use additional autoloaders it's possible that a class that isn't able to be loaded with this classmap autoloader will still be found (via another registered autoloader). Thus an exception should not be thrown when a class can't be autoloaded with this one.