### PR TITLE
Add driver options

### DIFF
--- a/ToolkitApi/Db2supp.php
+++ b/ToolkitApi/Db2supp.php
@@ -39,6 +39,7 @@ class db2supp
         if ($options) {
             $driver_options = array();
 
+            // Test for existence of driver options
             if (array_key_exists('driver_options', $options)) {
                 $driver_options = $options['driver_options'] ?: array();
             }

--- a/ToolkitApi/Db2supp.php
+++ b/ToolkitApi/Db2supp.php
@@ -3,7 +3,7 @@ namespace ToolkitApi;
 
 /**
  * Class db2supp
- * 
+ *
  * @todo define common transport class/interface extended/implemented by all transports
  *
  * @package ToolkitApi
@@ -14,8 +14,8 @@ class db2supp
     private $last_errormsg;
 
     /**
-     * 
-     * 
+     *
+     *
      * @todo Throw in your "transport/adapter" framework for a real OO look and feel ....
      * Throw new Exception("Fail execute ($sql) ".db2_stmt_errormsg(),db2_stmt_error());
      * ... and retrieve via try/catch + Exception methods.
@@ -32,10 +32,10 @@ class db2supp
         if ($user && empty($password)) {
             $this->setErrorCode('08001');
             $this->setErrorMsg('Authorization failure on distributed database connection attempt. SQLCODE=-30082');
-            
+
             return false;
         }
-        
+
         if ($options) {
             $driver_options = $options['driver_options'] ?: array();
 
@@ -49,10 +49,10 @@ class db2supp
                 return $conn;
             }
         }
-        
+
         $this->setErrorCode(db2_conn_error());
         $this->setErrorMsg(db2_conn_errormsg());
-          
+
         return false;
     }
 
@@ -65,12 +65,12 @@ class db2supp
             db2_close($conn);
         }
     }
-    
+
     /**
      * disconnect, truly close, a persistent connection.
-     * 
+     *
      * NOTE: Only available on i5/OS
-     * 
+     *
      * @param $conn
      */
     public function disconnectPersistent($conn)
@@ -98,10 +98,10 @@ class db2supp
 
     /**
      * set error code and message based on last db2 prepare or execute error.
-     * 
+     *
      * @todo: consider using GET DIAGNOSTICS for even more message text:
      * http://publib.boulder.ibm.com/infocenter/iseries/v5r4/index.jsp?topic=%2Frzala%2Frzalafinder.htm
-     * 
+     *
      * @param null $stmt
      */
     protected function setStmtError($stmt = null)
@@ -112,7 +112,7 @@ class db2supp
         } else {
             $this->setErrorCode(db2_stmt_error());
             $this->setErrorMsg(db2_stmt_errormsg());
-        }        
+        }
     }
 
     /**
@@ -130,10 +130,10 @@ class db2supp
     {
         $this->last_errormsg = $errorMsg;
     }
-    
+
     /**
      * this function used for special stored procedure call only
-     * 
+     *
      * @param $conn
      * @param $sql
      * @return bool
@@ -160,7 +160,7 @@ class db2supp
             array('position' => 3, 'name' => "inputXml",    'inout' => DB2_PARAM_IN),
             array('position' => 4, 'name' => "outputXml",   'inout' => DB2_PARAM_OUT),
         );
-        
+
         // bind the four parameters
         foreach ($params as $param) {
             $ret = db2_bind_param ($crsr, $param['position'], $param['name'], $param['inout']);
@@ -204,9 +204,9 @@ class db2supp
             }
         } else {
             $this->setStmtError();
-            Throw new \Exception("Failure executing SQL: ($sql) " . db2_stmt_errormsg(), db2_stmt_error()); 
+            Throw new \Exception("Failure executing SQL: ($sql) " . db2_stmt_errormsg(), db2_stmt_error());
         }
-         
+
         return $txt;
     }
 }

--- a/ToolkitApi/Db2supp.php
+++ b/ToolkitApi/Db2supp.php
@@ -37,7 +37,11 @@ class db2supp
         }
 
         if ($options) {
-            $driver_options = $options['driver_options'] ?: array();
+            $driver_options = array();
+
+            if (array_key_exists('driver_options', $options)) {
+                $driver_options = $options['driver_options'] ?: array();
+            }
 
             if ((isset($options['persistent'])) && $options['persistent']) {
                 $conn = db2_pconnect($database, $user, $password, $driver_options);

--- a/ToolkitApi/Db2supp.php
+++ b/ToolkitApi/Db2supp.php
@@ -37,12 +37,14 @@ class db2supp
         }
         
         if ($options) {
+            $driver_options = $options['driver_options'] ?: array();
+
             if ((isset($options['persistent'])) && $options['persistent']) {
-                $conn = db2_pconnect($database, $user, $password);
+                $conn = db2_pconnect($database, $user, $password, $driver_options);
             } else {
-                $conn = db2_connect($database, $user, $password);
+                $conn = db2_connect($database, $user, $password, $driver_options);
             }
-            
+
             if (is_resource($conn)) {
                 return $conn;
             }

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -653,9 +653,9 @@ class Toolkit
      *
      * @param string $pgmName Name of program to call, without library
      * @param string $lib Library of program. Leave blank to use library list or current library
-     * @param null $inputParam An array of ProgramParameter objects OR XML representing params, to be sent as-is.
-     * @param null $returnParam ReturnValue Array of one parameter that's the return value parameter
-     * @param null $options Array of other options. The most popular is 'func' indicating the name of a subprocedure or function.
+     * @param mixed[]|null $inputParam An array of ProgramParameter objects OR XML representing params, to be sent as-is.
+     * @param mixed[]|null $returnParam ReturnValue Array of one parameter that's the return value parameter
+     * @param mixed[]|null $options Array of other options. The most popular is 'func' indicating the name of a subprocedure or function.
      * @return array|bool
      */
     public function pgmCall($pgmName, $lib, $inputParam = NULL, $returnParam = NULL, $options = NULL)
@@ -1486,7 +1486,7 @@ class Toolkit
      * @param $scale
      * @param $comment
      * @param string $varName
-     * @param string $value
+     * @param mixed $value
      * @param int $dimension
      * @return PackedDecParam
      */
@@ -1501,7 +1501,7 @@ class Toolkit
      * @param $scale
      * @param $comment
      * @param string $varName
-     * @param string $value
+     * @param mixed $value
      * @param int $dimension
      * @return ZonedParam
      */
@@ -1563,7 +1563,7 @@ class Toolkit
      * @param int $dim
      * @param string $by
      * @param bool $isArray
-     * @param null $labelLen
+     * @param int|null $labelLen
      * @param string $comment
      * @param string $io
      * @return DataStructure
@@ -2384,7 +2384,7 @@ class Toolkit
      *
      * @param $heading
      * @param $key
-     * @param null $default
+     * @param mixed|null $default
      * @return bool|null
      */
     static function getConfigValue($heading, $key, $default = null)

--- a/ToolkitApi/ToolkitServiceParameter.php
+++ b/ToolkitApi/ToolkitServiceParameter.php
@@ -21,15 +21,15 @@ class ProgramParameter
     protected  $labelLen;  /* use this on a data structure to get the size/length */
     protected  $labelDoUntil = '';   /* use on a data structure array along with 'dim' to to set # of records to return based on labelEndDo (see below) */
     protected  $labelEndDo = '';  /* use this on an integer "count" field to control the number of records to return in n array data structure (see labelDoUntil above) */
-    
+
     // CCSID/hex support
     protected $_ccsidBefore;
     protected $_ccsidAfter;
     protected $_useHex;
-    
+
     // if data field is not named, the toolkit creates a name of the pattern var0, var1, var2...
     static protected $_fallbackNameSequence = 0; // start with zero to give unnamed elements a unique name
-    
+
     // @todo do setlen for other program param types, too
 
     /**
@@ -42,8 +42,8 @@ class ProgramParameter
      * @param int $dimension
      * @param string $by
      * @param bool $isArray
-     * @param null $labelSetLen
-     * @param null $labelLen
+     * @param int|null $labelSetLen
+     * @param int|null $labelLen
      * @param string $ccsidBefore
      * @param string $ccsidAfter
      * @param bool $useHex
@@ -69,8 +69,8 @@ class ProgramParameter
         $this->labelLen        = $labelLen;
         $this->_ccsidBefore    = $ccsidBefore;
         $this->_ccsidAfter     = $ccsidAfter;
-        $this->_useHex         = $useHex;    
-        
+        $this->_useHex         = $useHex;
+
     }
 
     /**
@@ -80,9 +80,9 @@ class ProgramParameter
     {
         // if varName is empty then set a fallback unique varName.
         if (!$this->varName) {
-            $this->varName = $this->getFallbackVarName(); 
+            $this->varName = $this->getFallbackVarName();
         }
-        
+
         return array('type' => $this->type,
                   'io' => $this->io,
                   'comment' => $this->comment,
@@ -104,7 +104,7 @@ class ProgramParameter
 
     /**
      * spell it right
-     * 
+     *
      * @return array
      */
     public function getParamProperties()
@@ -115,7 +115,7 @@ class ProgramParameter
     /**
      * set a parameter's properties via an key=>value array structure. Choose any properties to set.
      * map the XML keywords (usually shorter than true class property names) to the class property names.
-     * 
+     *
      * @param array $properties
      */
     public function setParamProperties($properties = array())
@@ -142,7 +142,7 @@ class ProgramParameter
         // using the mapping above to find the true property name.
         foreach ($properties as $key=>$value) {
             $propName = isset($map[$key]) ? $map[$key] : '';
-            
+
             if ($propName) {
                 // a valid property name was found so set it
                 $this->$propName = $value;
@@ -160,19 +160,19 @@ class ProgramParameter
 
     /**
      * for unnamed data elements, provide a unique name: var0, var1, var2...
-     * 
+     *
      * @return string
      */
     protected function getFallbackVarName()
     {
         $varName =  'var' . self::$_fallbackNameSequence++;
-        
+
         return $varName;
     }
 
     /**
      * if $value is an array, but not yet a data structure, make a data structure of the array elements.
-     * 
+     *
      * @param $type
      * @param $io
      * @param $comment
@@ -226,7 +226,7 @@ class ProgramParameter
 
     /**
      * set "len label"
-     * 
+     *
      * @param $labelLen
      */
     public function setParamLabelLen($labelLen)
@@ -278,7 +278,7 @@ class ProgramParameter
 
     /**
      * for a data structure or other item in an array, set the label for "do until"
-     * 
+     *
      * @param string $label
      * @return $this
      */
@@ -289,10 +289,10 @@ class ProgramParameter
     }
 
     /**
-     * for a numeric counter field that will determine how many array elements return 
-     * from a program call, set the label for "enddo". Links up with the Dou label 
+     * for a numeric counter field that will determine how many array elements return
+     * from a program call, set the label for "enddo". Links up with the Dou label
      * given to the dim'med array element itself.
-     * 
+     *
      * @param string $label
      * @return $this
      */
@@ -304,11 +304,11 @@ class ProgramParameter
 
     /**
      * "CCSID before" means how to convert to CCSID on the way in to XMLSERVICE, when needed
-     * 
+     *
      * @param string $ccsidBefore
      * @return $this
-     */ 
-    public function setParamCcsidBefore($ccsidBefore = '') 
+     */
+    public function setParamCcsidBefore($ccsidBefore = '')
     {
         $this->_ccsidBefore = $ccsidBefore;
         return $this; // fluent interface
@@ -316,7 +316,7 @@ class ProgramParameter
 
     /**
      * "CCSID after" means how to convert to CCSID on the way out from XMLSERVICE, when needed
-     * 
+     *
      * @param string $ccsidAfter
      * @return $this
      */
@@ -328,7 +328,7 @@ class ProgramParameter
 
     /**
      * "useHex" controls whether the data will be converted to/from hex
-     * 
+     *
      * @param bool $useHex
      * @return $this
      */
@@ -390,7 +390,7 @@ class ProgramParameter
      * bin2str is used by the 5250 Bridge. It converts a hex string to character string
      * while cleaning up unexpected characters.
      * Original comment: "can not be public. Return XML does not return a type of values."
-     * 
+     *
      * @param $hex_data
      * @return string
      */
@@ -406,12 +406,12 @@ class ProgramParameter
              */
              if ($hex_data[$i] == '0') {
                  $hexPair = '20'; // space
-             } //(if($hex_data[$i] == '0') ) 
+             } //(if($hex_data[$i] == '0') )
              // break;
              $str.= chr(hexdec($hexPair));
              //$str.= chr(hexdec($hex_data[$i].$hex_data [$i+1]));
         }
-        
+
         return $str;
      }
 }
@@ -425,16 +425,16 @@ class DataStructure extends ProgramParameter
 {
 
     /**
-     * v1.4.0 added $comment as arg 5, in place of the obsolete $isReturnParam argument. 
+     * v1.4.0 added $comment as arg 5, in place of the obsolete $isReturnParam argument.
      * Data structure return values didn't work properly before 1.4.0 anyway.
-     * 
+     *
      * @param $paramsArray
      * @param string $struct_name
      * @param int $dim
      * @param string $comment
      * @param string $by
      * @param bool $isArray
-     * @param null $labelLen
+     * @param int|null $labelLen
      * @param string $io
      */
     function __construct($paramsArray, $struct_name ="DataStruct", $dim=0, $comment = '', $by='', $isArray=false, $labelLen = null, $io = 'both')
@@ -445,7 +445,7 @@ class DataStructure extends ProgramParameter
 
 /**
  * Class CharParam
- * 
+ *
  * CharParam can require hex/ccsid conversions, which other types don't.
  *
  * @package ToolkitApi
@@ -454,7 +454,7 @@ class CharParam extends ProgramParameter
 {
     /**
      * @todo if array. call charparm 5 times with fake field name and coming out, too. (?)
-     * 
+     *
      * @param $io
      * @param $size
      * @param string $comment
@@ -519,11 +519,11 @@ class PackedDecParam extends ProgramParameter
      * @param string $scale
      * @param string $comment
      * @param string $varName
-     * @param string $value
+     * @param mixed $value
      * @param int $dimension
      * @param string $by
      * @param bool $isArray
-     * @param null $labelSetLen
+     * @param int|null $labelSetLen
      */
     function __construct($io, $length, $scale, $comment,  $varName = '', $value, $dimension=0, $by='', $isArray = false,  $labelSetLen = null)
     {
@@ -548,7 +548,7 @@ class Int32Param extends ProgramParameter
      * @param int $dimension
      * @param string $by
      * @param bool $isArray
-     * @param null $labelSetLen
+     * @param int|null $labelSetLen
      */
      function __construct($io, $comment, $varName = '', $value, $dimension=0, $by='', $isArray = false, $labelSetLen = null)
      {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zendtech/ibmitoolkit",
+    "name": "guidofaecke/ibmitoolkit",
     "description": "PHP frontend to XMLSERVICE for IBM i development.",
     "keywords": ["ibmitoolkit","ibmxmltoolkit","XMLSERVICE","IBM i","zend","as400"],
     "license": "BSD-3-Clause",
@@ -13,6 +13,11 @@
             "name": "Chuk Shirley",
             "email": "chukShirley@gmail.com",
             "homepage": "http://github.com/chukShirley"
+        },
+        {
+            "name" : "Guido Faecke",
+            "email" : "guido@faecke.us",
+            "homepage" : "http://faecke.us"
         }
     ],
     "require": {


### PR DESCRIPTION
Missing driver_options can switch existing QSQSRVR jobs from SYSTEM naming to SQL naming, which causes trouble with unqualified calls and executions.