### PR TITLE
Update toolkit.ini with IBM-shipped library name

### DIFF
--- a/ToolkitApi/toolkit.ini
+++ b/ToolkitApi/toolkit.ini
@@ -2,9 +2,9 @@
 ; with default values appropriate for Zend Server 9
 ;comment
 [system]
-; set library where XTOOLKIT lives, most likely XMLSERVICE (testing) or ZENDPHP7 (production)
-XMLServiceLib = "ZENDPHP7" ; production Zend Server 9.x
-;XMLServiceLib = "XMLSERVICE" ; for testing new XMLSERVICE packages
+; set library where XMLSERVICE objects live
+XMLServiceLib = "QXMLSERV" ; Library for XMLSERVICE shipped by IBM
+;XMLServiceLib = "ZENDPHP7" ; production Zend Server 9.x
 
 ; Location of ZSXMLSRV "helper" service program. Overrides ToolkitServiceSet's ZSTOOLKITLIB constant 
 HelperLib = "ZENDPHP7" ; library of ZS "helper" service program. ZENDSVR, ZENDSVR6, or ZENDPHP7


### PR DESCRIPTION
- Change library to QXMLSERV.
- Remove comment about test library XMLSERVICE because that will be seldom used nowadays
- Update comments for accuracy

Fixes #107 