### PR TITLE
type checking for databaseNameOrResource

### DIFF
--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -136,7 +136,7 @@ class Toolkit implements ToolkitInterface
     /**
      * if passing an existing resource and naming, don't need the other params.
      *
-     * @param $databaseNameOrResource
+     * @param string|resource $databaseNameOrResource
      * @param string $userOrI5NamingFlag 0 = DB2_I5_NAMING_OFF or 1 = DB2_I5_NAMING_ON
      * @param string $password
      * @param string $transportType (http, ibm_db2, odbc)
@@ -147,6 +147,22 @@ class Toolkit implements ToolkitInterface
     {
         $this->execStartTime = '';
 
+        // stop any types that are not valid for first parameter. Invalid values may cause toolkit to try to create another database connection.
+        if (!is_string($databaseNameOrResource) && !is_resource($databaseNameOrResource) {
+
+            // initialize generic message
+            $this->error = "\nFailed to connect. databaseNameOrResource " . var_export($databaseNameOrResource, true) . " not valid.";
+
+            // change to a more specific helpful message if a boolean false arising from a failed database connection passed in
+            if (false === $databaseNameOrResource) {
+                $this->error = "\nFailed to connect. If you passed in a database connection, it was a failed one with a value of false.";
+            }
+            
+            $this->debugLog($this->error);
+            throw new \Exception($this->error);
+            
+        } // (if (!is_string....)               
+     
         // set service parameters to use in object.
         $this->serviceParams = $this->getDefaultServiceParams();
 

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -148,7 +148,7 @@ class Toolkit implements ToolkitInterface
         $this->execStartTime = '';
 
         // stop any types that are not valid for first parameter. Invalid values may cause toolkit to try to create another database connection.
-        if (!is_string($databaseNameOrResource) && !is_resource($databaseNameOrResource) {
+        if (!is_string($databaseNameOrResource) && !is_resource($databaseNameOrResource)) {
 
             // initialize generic message
             $this->error = "\nFailed to connect. databaseNameOrResource " . var_export($databaseNameOrResource, true) . " not valid.";

--- a/tests/ToolkitApiTest/ToolkitTest.php
+++ b/tests/ToolkitApiTest/ToolkitTest.php
@@ -4,6 +4,7 @@ namespace ToolkitApiTest;
 use PHPUnit\Framework\TestCase;
 use ToolkitApi\BinParam;
 use ToolkitApi\CharParam;
+use ToolkitApi\DataArea;
 use ToolkitApi\FloatParam;
 use ToolkitApi\HoleParam;
 use ToolkitApi\Int16Param;
@@ -21,6 +22,7 @@ use ToolkitApi\UInt32Param;
 use ToolkitApi\UInt64Param;
 use ToolkitApi\UInt8Param;
 use ToolkitApi\ZonedParam;
+use Exception;
 
 /**
  * Class ToolkitTest
@@ -185,6 +187,48 @@ final class ToolkitTest extends TestCase
         $isRunningOnIbmI = (php_uname('s') === 'OS400');
 
         $this->assertEquals($isRunningOnIbmI, $this->toolkit->isPhpRunningOnIbmI());
+    }
+
+    public function testDatabaseNameOrResourceIsNotBoolean()
+    {
+        $resource = false;
+        $this->expectException(Exception::class);
+        new Toolkit($resource);
+    }
+
+    public function testDatabaseNameOrResourceIsNotFloat()
+    {
+        $resource = 1.81;
+        $this->expectException(Exception::class);
+        new Toolkit($resource);
+    }
+
+    public function testDatabaseNameOrResourceIsNotObject()
+    {
+        $resource = new DataArea();
+        $this->expectException(Exception::class);
+        new Toolkit($resource);
+    }
+
+    public function testDatabaseNameOrResourceIsNotInteger()
+    {
+        $resource = 12;
+        $this->expectException(Exception::class);
+        new Toolkit($resource);
+    }
+
+    public function testDatabaseNameOrResourceIsNotArray()
+    {
+        $resource = array(1, 2, 3);
+        $this->expectException(Exception::class);
+        new Toolkit($resource);
+    }
+
+    public function testDatabaseNameOrResourceIsNotNull()
+    {
+        $resource = null;
+        $this->expectException(Exception::class);
+        new Toolkit($resource);
     }
 
 }


### PR DESCRIPTION
Prevent toolkit from misinterpreting invalid first parameter, especially if it is boolean false.