### PR TITLE
Add the require of cwclasses.php

### DIFF
--- a/ToolkitApi/CW/cw.php
+++ b/ToolkitApi/CW/cw.php
@@ -7,6 +7,8 @@ use ToolkitApi\ListFromApi;
 use ToolkitApi\DataArea;
 use ToolkitApi\UserSpace;
 
+require_once 'cwclasses.php';
+
 /**
  * Procedural Compatibility Wrapper for IBM i Toolkit for PHP
  */


### PR DESCRIPTION
At some point, the require of cwclasses.php got dropped from cw.php. This commit adds it back so that the Compatibility Wrapper (CW) can work again. Fixes #117 