### PR TITLE
Check for PDO class

### DIFF
--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -148,7 +148,7 @@ class Toolkit implements ToolkitInterface
         $this->execStartTime = '';
 
         // stop any types that are not valid for first parameter. Invalid values may cause toolkit to try to create another database connection.
-        if (!is_string($databaseNameOrResource) && !is_resource($databaseNameOrResource)) {
+        if (!is_string($databaseNameOrResource) && !is_resource($databaseNameOrResource) && ((!is_object($databaseNameOrResource) || (is_object($databaseNameOrResource) && get_class($databaseNameOrResource) !== PDO::class)))) {
 
             // initialize generic message
             $this->error = "\nFailed to connect. databaseNameOrResource " . var_export($databaseNameOrResource, true) . " not valid.";


### PR DESCRIPTION
When validating $databaseNameOrResource, we need to allow for the PDO class. This change eliminates the error message "Failed to connect. databaseNameOrResource PDO::__set_state(array(
)) not valid"