### PR TITLE
Explicitly check for false in makeDbCall()

### DIFF
--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -906,7 +906,7 @@ class Toolkit implements ToolkitInterface
 
         // can return false if prepare or exec failed.
         $outputXml = $this->db->execXMLStoredProcedure($this->conn, $sql, $bindArray);
-        if (!$outputXml) {
+        if (false === $outputXml) {
             // if false returned, was a database error (stored proc prepare or execute error)
             // @todo add ODBC SQL State codes
 


### PR DESCRIPTION
Fixes #129 
The code's intent was to handle database errors, which return false, but because the code checked for !$outputXml, it interpreted an empty strings as an error, reporting "errors" that were merely empty output. This occurred, for example, when doing a disconnect() with the PDO transport. Now we check for false explicitly.