### PR TITLE
Fix argument order of implode

### DIFF
--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -339,7 +339,7 @@ class Toolkit implements ToolkitInterface
      */
     protected function validPlugSizeList()
     {
-        return implode($this->validPlugSizes(), ', ');
+        return implode(', ', $this->validPlugSizes());
     }
 
     /**


### PR DESCRIPTION
The glue comes before the pieces; the other way around was
deprecated in PHP 7.4.