### PR TITLE
Removed PDO transaction for execXMLStoredProcedure()

### DIFF
--- a/ToolkitApi/PdoSupp.php
+++ b/ToolkitApi/PdoSupp.php
@@ -124,7 +124,6 @@ final class PdoSupp
      */
     public function execXMLStoredProcedure($conn, $stmt, $bindArray)
     {
-        $conn->beginTransaction();
         $statement = $conn->prepare($stmt);
 
         if (!$statement) {
@@ -137,8 +136,6 @@ final class PdoSupp
             $bindArray['controlKey'],
             $bindArray['inputXml']
         ));
-
-        $conn->commit();
 
         if (!$result) {
             $this->setError($conn);


### PR DESCRIPTION
Removed transaction that was causing errors binding XML parameter to the PDO execute() function.

Issue:  
https://github.com/zendtech/IbmiToolkit/issues/140