### PR TITLE
WIP: SSH transport for Toolkit

### DIFF
--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -100,8 +100,15 @@ class SshSupp
             $this->setErrorMsg("error connecting to SSH");
             return false;        
         }
-        // XXX: Check fingerprint here
-        $fingerprint = ssh2_fingerprint($conn, SSH2_FINGERPRINT_MD5 | SSH2_FINGERPRINT_HEX);
+        // XXX: should probably be doing better than SHA1 here, but ssh2
+        $remoteFP = ssh2_fingerprint($conn, SSH2_FINGERPRINT_SHA1 | SSH2_FINGERPRINT_HEX);
+        $trustedFP = array_key_exists("sshFingerprint", $options) ? $options["sshFingerprint"] : false;
+        if ($trustedFP !== false && $trustedFP !== $remoteFP) {
+            $this->setErrorCode("SSH2_FINGERPRINT");
+            $this->setErrorMsg("the fingerprint ($remoteFP) differs from the set fingerprint");
+            ssh2_disconnect($conn);
+            return false;
+        }
         // XXX: Public key auth
         if (!ssh2_auth_password($conn, $user, $password)) {
             $this->setErrorCode("SSH2_AUTH_PASSWORD");

--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -18,18 +18,28 @@ class SshSupp
      * @param $xmlIn
      * @return string|bool
      */
-    public function send($xmlIn, $byteSize)
+    public function send($xmlIn)
     {
         // xmlservice-cli takes no options in regards to statefulness
         // (IpcDir, etc) or byte size
-        $exec_res = ssh2_exec($this->conn, "/QOpenSys/pkgs/bin/xmlservice-cli");
-        if (!$exec_res) {
+        $ssh_stdio = ssh2_exec($this->conn, "/QOpenSys/pkgs/bin/xmlservice-cli");
+        if (!$ssh_stdio) {
+            $this->setErrorCode("SSH2_EXEC");
             $this->setErrorMsg("error executing command over SSH");
             return false;
+	}
+	/* XXX */
+        stream_set_blocking($ssh_stdio, true);
+        $written = fwrite($ssh_stdio, $xmlIn);
+        if ($written === false) {
+            $this->setErrorCode("SSH2_FWRITE");
+            $this->setErrorMsg("error writing to stdin");
+            return false;
         }
-        fwrite($exec_res, $xmlIn);
-        
-        return stream_get_contents($exec_res);
+        fflush($ssh_stdio);
+        ssh2_send_eof($ssh_stdio);
+        $xmlOut = stream_get_contents($ssh_stdio);
+        return $xmlOut;
     }
 
     /**
@@ -72,15 +82,29 @@ class SshSupp
      */
     public function connect($server, $user, $password, $options = array())
     {
+        // Only post-1.2 versions of ssh2 have ssh2_send_eof
+        if (!extension_loaded("ssh2")) {
+            $this->setErrorCode("SSH2_NOT_LOADED");
+            $this->setErrorMsg("the ssh2 extension isn't loaded");
+            return false;
+        }
+        if (!function_exists("ssh2_send_eof")) {
+            $this->setErrorCode("SSH2_NO_SEND_EOF");
+            $this->setErrorMsg("the ssh2 extension is too old to support ssh2_end_eof");
+            return false;
+        }
         // XXX: Set options on ourself here
         $conn = ssh2_connect($server, 22);
         if (!$conn) {
+            $this->setErrorCode("SSH2_CONNECT");
             $this->setErrorMsg("error connecting to SSH");
             return false;        
         }
         // XXX: Check fingerprint here
+        $fingerprint = ssh2_fingerprint($conn, SSH2_FINGERPRINT_MD5 | SSH2_FINGERPRINT_HEX);
         // XXX: Public key auth
-        if (!ssh2_auth_password($conn, $user, $password) {
+        if (!ssh2_auth_password($conn, $user, $password)) {
+            $this->setErrorCode("SSH2_AUTH_PASSWORD");
             $this->setErrorMsg("error performing password auth over SSH");
             return false;        
         }

--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -130,6 +130,7 @@ class SshSupp
      * @param string $server
      * @param $user
      * @param $password
+     * @param array $options
      * @return SshSupp|bool
      */
     public function connect($server, $user, $password, $options = array())
@@ -137,8 +138,9 @@ class SshSupp
         if (!$this->checkCompat()) {
             return false;
         }
-        // XXX: Set options on ourself here
-        $conn = ssh2_connect($server, 22);
+        // XXX: Set advanced methods here
+        $port = array_key_exists("sshPort", $options) ? $options["sshPort"] : 22;
+        $conn = ssh2_connect($server, $port);
         if (!$conn) {
             $this->setErrorCode("SSH2_CONNECT");
             $this->setErrorMsg("error connecting to SSH");

--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -92,13 +92,7 @@ class SshSupp
         return $this->xmlserviceCliPath;
     }
 
-    /**
-     * @param string $server
-     * @param $user
-     * @param $password
-     * @return SshSupp|bool
-     */
-    public function connect($server, $user, $password, $options = array())
+    private function checkCompat()
     {
         // Only post-1.2 versions of ssh2 have ssh2_send_eof
         if (!extension_loaded("ssh2")) {
@@ -109,6 +103,38 @@ class SshSupp
         if (!function_exists("ssh2_send_eof")) {
             $this->setErrorCode("SSH2_NO_SEND_EOF");
             $this->setErrorMsg("the ssh2 extension is too old to support ssh2_send_eof");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param resource $conn
+     * @return SshSupp|bool
+     */
+    public function connectWithExistingConnection($conn)
+    {
+        if (!$this->checkCompat()) {
+            return false;
+        }
+        if (!$conn || !is_resource($conn)) {
+            $this->setErrorCode("SSH2_NOT_RESOURCE");
+            $this->setErrorMsg("connection isn't a valid resource");
+            return false;
+        }
+        $this->conn = $conn;
+        return $this;
+    }
+
+    /**
+     * @param string $server
+     * @param $user
+     * @param $password
+     * @return SshSupp|bool
+     */
+    public function connect($server, $user, $password, $options = array())
+    {
+        if (!$this->checkCompat()) {
             return false;
         }
         // XXX: Set options on ourself here

--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -14,6 +14,8 @@ class SshSupp
 
     protected $conn;
 
+    protected $xmlserviceCliPath;
+
     /**
      * @param $xmlIn
      * @return string|bool
@@ -22,7 +24,7 @@ class SshSupp
     {
         // xmlservice-cli takes no options in regards to statefulness
         // (IpcDir, etc) or byte size
-        $ssh_stdio = ssh2_exec($this->conn, "/QOpenSys/pkgs/bin/xmlservice-cli");
+        $ssh_stdio = ssh2_exec($this->conn, $this->getXmlserviceCliPath());
         if (!$ssh_stdio) {
             $this->setErrorCode("SSH2_EXEC");
             $this->setErrorMsg("error executing command over SSH");
@@ -72,6 +74,22 @@ class SshSupp
     protected function setErrorMsg($errorMsg)
     {
         $this->last_errormsg = $errorMsg;
+    }
+
+    /**
+     * @param string $path
+     */
+    public function setXmlserviceCliPath($path)
+    {
+        $this->xmlserviceCliPath = $path;
+    }
+
+    /**
+     * @return null
+     */
+    public function getXmlserviceCliPath()
+    {
+        return $this->xmlserviceCliPath;
     }
 
     /**

--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -27,8 +27,8 @@ class SshSupp
             $this->setErrorCode("SSH2_EXEC");
             $this->setErrorMsg("error executing command over SSH");
             return false;
-	}
-	/* XXX */
+        }
+        /* XXX */
         stream_set_blocking($ssh_stdio, true);
         $written = fwrite($ssh_stdio, $xmlIn);
         if ($written === false) {
@@ -90,7 +90,7 @@ class SshSupp
         }
         if (!function_exists("ssh2_send_eof")) {
             $this->setErrorCode("SSH2_NO_SEND_EOF");
-            $this->setErrorMsg("the ssh2 extension is too old to support ssh2_end_eof");
+            $this->setErrorMsg("the ssh2 extension is too old to support ssh2_send_eof");
             return false;
         }
         // XXX: Set options on ourself here

--- a/ToolkitApi/SshSupp.php
+++ b/ToolkitApi/SshSupp.php
@@ -1,0 +1,99 @@
+<?php
+namespace ToolkitApi;
+
+/**
+ * 
+ * @todo define common transport class/interface extended/implemented by all transports. They have much in common.
+ * 
+ * @package ToolkitApi
+ */
+class SshSupp
+{
+    protected $last_errorcode;
+    protected $last_errormsg;
+
+    protected $conn;
+
+    /**
+     * @param $xmlIn
+     * @return string|bool
+     */
+    public function send($xmlIn, $byteSize)
+    {
+        // xmlservice-cli takes no options in regards to statefulness
+        // (IpcDir, etc) or byte size
+        $exec_res = ssh2_exec($this->conn, "/QOpenSys/pkgs/bin/xmlservice-cli");
+        if (!$exec_res) {
+            $this->setErrorMsg("error executing command over SSH");
+            return false;
+        }
+        fwrite($exec_res, $xmlIn);
+        
+        return stream_get_contents($exec_res);
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorCode()
+    {
+        return $this->last_errorcode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMsg()
+    {
+        return $this->last_errormsg;
+    }
+
+    /**
+     * @param $errorCode
+     */
+    protected function setErrorCode($errorCode)
+    {
+        $this->last_errorcode = $errorCode;
+    }
+
+    /**
+     * @param $errorMsg
+     */
+    protected function setErrorMsg($errorMsg)
+    {
+        $this->last_errormsg = $errorMsg;
+    }
+
+    /**
+     * @param string $server
+     * @param $user
+     * @param $password
+     * @return SshSupp|bool
+     */
+    public function connect($server, $user, $password, $options = array())
+    {
+        // XXX: Set options on ourself here
+        $conn = ssh2_connect($server, 22);
+        if (!$conn) {
+            $this->setErrorMsg("error connecting to SSH");
+            return false;        
+        }
+        // XXX: Check fingerprint here
+        // XXX: Public key auth
+        if (!ssh2_auth_password($conn, $user, $password) {
+            $this->setErrorMsg("error performing password auth over SSH");
+            return false;        
+        }
+        
+        $this->conn = $conn;
+    
+        return $this;
+    }
+    
+    public function disconnect()
+    {
+        if (is_resource($this->conn)) {
+            ssh2_disconnect($this->conn);
+        }
+    }
+}

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -858,7 +858,8 @@ class Toolkit implements ToolkitInterface
 
             // if debug mode, log control key, and input XML.
             if ($this->isDebug()) {
-                $this->debugLog("\nExec start: " . date("Y-m-d H:i:s") . "\nVersion of toolkit front end: " . self::getFrontEndVersion() ."\nToolkit class: '" . __FILE__ . "'\nIPC: '" . $this->getInternalKey() . "'. Control key: $controlKeyString\nHost URL: $url\nExpected output size (plugSize): $plugSize or $outByteSize bytes\nInput XML: $inputXml\n");
+                // SSH transport doesn't use IPC/CTL/out sizes, don't mention them
+                $this->debugLog("\nExec start: " . date("Y-m-d H:i:s") . "\nVersion of toolkit front end: " . self::getFrontEndVersion() ."\nToolkit class: '" . __FILE__ . "'\nInput XML: $inputXml\n");
                 $this->execStartTime = microtime(true);
             }
 

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -139,7 +139,7 @@ class Toolkit implements ToolkitInterface
      * @param string|resource $databaseNameOrResource
      * @param string $userOrI5NamingFlag 0 = DB2_I5_NAMING_OFF or 1 = DB2_I5_NAMING_ON
      * @param string $password
-     * @param string $transportType (http, ibm_db2, odbc)
+     * @param string $transportType (http, ibm_db2, odbc, ssh)
      * @param bool $isPersistent
      * @throws \Exception
      */
@@ -375,15 +375,19 @@ class Toolkit implements ToolkitInterface
     }
 
     /**
-     * Choose data transport type: ibm_db2, odbc, http
+     * Choose data transport type: ibm_db2, odbc, http, ssh
      *
-     * @param string $transportName 'ibm_db2' or 'odbc' or 'http'
+     * @param string $transportName 'ibm_db2' or 'odbc' or 'http' or 'ssh'
      * @throws \Exception
      */
     protected function chooseTransport($transportName = '')
     {
         switch($transportName)
         {
+            case 'ssh':
+                $transport = new SshSupp();
+                $this->setTransport($transport);
+                break;
             case 'http':
                 $transport = new httpsupp();
                 $transport->setUrl(

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -234,11 +234,16 @@ class Toolkit implements ToolkitInterface
                 $this->debugLog("Re-using existing db connection with schema separator: $schemaSep");
             }
         } elseif ($transportType === 'ssh') {
-            $databaseName = $databaseNameOrResource;
             $user = $userOrI5NamingFlag;
             $this->chooseTransport($transportType);
             $transport = $this->getTransport();
-            $conn = $transport->connect($databaseName, $user, $password, $options);
+            if (is_resource($databaseNameOrResource)) {
+                $sshConn = $databaseNameOrResource;
+                $conn = $transport->connectWithExistingConnection($sshConn);
+            } else {
+                $serverName = $databaseNameOrResource;
+                $conn = $transport->connect($serverName, $user, $password, $options);
+            }
         } elseif ($transportType === 'http' || $transportType === 'https') {
             $databaseName = $databaseNameOrResource;
             $user = $userOrI5NamingFlag;

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -102,6 +102,7 @@ class Toolkit implements ToolkitInterface
                                 'transportType'  => 'ibm_db2', // can override in getInstance constructor as well
                                 'httpTransportUrl' => '', // for HTTP REST transport
                                 'timeReport'      => false, // *fly or *nofly; if true, return tick counts instead of data.
+                                'xmlserviceCliPath' => '/QOpenSys/pkgs/bin/xmlservice-cli', // The path to the xmlservice-cli program (or compatible API) on the IBM i system. The full path should be used because $PATH may not be set up.
     );
 
     // plug size to bytes cross-reference
@@ -401,6 +402,9 @@ class Toolkit implements ToolkitInterface
         {
             case 'ssh':
                 $transport = new SshSupp();
+                $transport->setXmlserviceCliPath(
+                    $this->getOption('xmlserviceCliPath')
+                );
                 $this->setTransport($transport);
                 break;
             case 'http':
@@ -853,8 +857,8 @@ class Toolkit implements ToolkitInterface
             $result = $this->makeDbCall($internalKey, $plugSize, $controlKeyString, $inputXml, $disconnect);
         } else if ($this->getTransport() instanceof SshSupp) {
             $transport = $this->getTransport();
-            // This is where we reset options like is done in the switch
-            // block that makes the transport for us
+            $xmlserviceCliPath = $this->getOption('xmlserviceCliPath');
+            $transport->setXmlserviceCliPath($xmlserviceCliPath);
 
             // if debug mode, log control key, and input XML.
             if ($this->isDebug()) {

--- a/ToolkitApi/ToolkitService.php
+++ b/ToolkitApi/ToolkitService.php
@@ -17,7 +17,7 @@ class ToolkitService
      * @param string $userOrI5NamingFlag
      * @param string $password
      * @param string $transportType
-     * @param bool $isPersistent
+     * @param bool|array $isPersistent
      * @return bool|null
      */
     static function getInstance($databaseNameOrResource = '*LOCAL', $userOrI5NamingFlag = '', $password = '', $transportType = '', $isPersistent = false)

--- a/ToolkitApi/autoload.php
+++ b/ToolkitApi/autoload.php
@@ -8,6 +8,7 @@ spl_autoload_register(function($class){
         'ToolkitApi\ToolkitInterface'   => __DIR__ . DIRECTORY_SEPARATOR . 'ToolkitInterface.php',
         'ToolkitApi\db2supp'            => __DIR__ . DIRECTORY_SEPARATOR . 'Db2supp.php',
         'ToolkitApi\httpsupp'           => __DIR__ . DIRECTORY_SEPARATOR . 'httpsupp.php',
+        'ToolkitApi\SshSupp'            => __DIR__ . DIRECTORY_SEPARATOR . 'SshSupp.php',
         'ToolkitApi\DateTimeApi'        => __DIR__ . DIRECTORY_SEPARATOR . 'DateTimeApi.php',
         'ToolkitApi\ListFromApi'        => __DIR__ . DIRECTORY_SEPARATOR . 'ListFromApi.php',
         'ToolkitApi\UserSpace'          => __DIR__ . DIRECTORY_SEPARATOR . 'UserSpace.php',

--- a/samples/ssh-transport.php
+++ b/samples/ssh-transport.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This sample uses the new SSH transport to connect to a remote IBM i system.
+ * You need the package "itoolkit-utils" (for xmlservice-cli) installed on the remote system.
+ * On the system running the Toolkit, you need a version of the ssh2 PECL extension installed that has "ssh2_send_eof".
+ * (Versions newer than 1.2 should include it.)
+ * This uses the API change to provide flexibility in configuring the transport without having to set global options.
+ * For example, you can three kinds of authentication methods:
+ * - password (default): use the password like other methods.
+ * - keyfile: SSH keys (with optional passphrase)
+ * - agent: Use the running SSH agent (no need to embed credentials)
+ */
+
+require_once('ToolkitApi/ToolkitService.php');
+try {
+	$options = array(
+		// If this is omitted or set to false, then the Toolkit won't validate the remote fingerprint.
+		// You can set this to gain additional security (that the remote server isn't an impostor).
+		// A hex string is used. You can get the fingerprint in the required form by running:
+		//   $conn = ssh2_connect($server, 22);
+		//   echo ssh2_fingerprint($conn, SSH2_FINGERPRINT_SHA1 | SSH2_FINGERPRINT_HEX);
+		"sshFingerprint" => "EADDEA1EB936B3C6F7D7E5A380B6BB607E71259D",
+		// By default, the password like other transports is used by default, but you can use another method like so:
+		"sshMethod" => "agent",
+		// The password is ignored if not using password authentication.
+		// No additional parameters are used for the agent.
+		// This is ideal because you don't need to embed credentials.
+		// Your development environment likely has a working agent too!
+		// Want to use SSH keys? Try something like...
+		/*
+		"sshMethod" => "keyfile",
+		"sshPublicKeyFile" => "/home/calvin/.ssh/id_rsa.pub",
+		"sshPrivateKeyFile" => "/home/calvin/.ssh/id_rsa",
+		// (optional)
+		"sshPassphrase" => "dubnobasswithmyheadman"
+		 */
+	);
+	$tkobj = ToolkitService::getInstance("hostname", "username", '', "ssh", $options);
+	$res = $tkobj->CLInteractiveCommand("DSPLIBL");
+	var_dump($res);
+} catch (Exception $e) {
+	echo $e->getMessage(), "\n";
+}

--- a/samples/ssh-transport.php
+++ b/samples/ssh-transport.php
@@ -38,6 +38,8 @@ try {
 		// (optional)
 		"sshPassphrase" => "dubnobasswithmyheadman"
 		 */
+		// Override the port number
+		"sshPort" => 22,
 	);
 	$tkobj = ToolkitService::getInstance("hostname", "username", '', "ssh", $options);
 	$res = $tkobj->CLInteractiveCommand("DSPLIBL");

--- a/samples/ssh-transport.php
+++ b/samples/ssh-transport.php
@@ -10,10 +10,13 @@
  * - password (default): use the password like other methods.
  * - keyfile: SSH keys (with optional passphrase)
  * - agent: Use the running SSH agent (no need to embed credentials)
+ * Alternatively, you can pass in an existing ssh2 resource that you've set up yourself,
+ * in case the Toolkit doesn't support the scenario you want.
  */
 
 require_once('ToolkitApi/ToolkitService.php');
 try {
+	// Letting Toolkit set it up for you:
 	$options = array(
 		// If this is omitted or set to false, then the Toolkit won't validate the remote fingerprint.
 		// You can set this to gain additional security (that the remote server isn't an impostor).
@@ -38,6 +41,11 @@ try {
 	);
 	$tkobj = ToolkitService::getInstance("hostname", "username", '', "ssh", $options);
 	$res = $tkobj->CLInteractiveCommand("DSPLIBL");
+	var_dump($res);
+	// Setting it up yourself:
+	$sshConn = ssh2_connect(hostname, 2222); // for example, custom port
+	ssh2_auth_agent($sshConn, "username"); // simple example
+	$tkobj = ToolkitService::getInstance($sshConn, "", "", "ssh");
 	var_dump($res);
 } catch (Exception $e) {
 	echo $e->getMessage(), "\n";


### PR DESCRIPTION
Uses PECL ssh2 (requires bleeding edge version to have `ssh2_send_eof`), requires `xmlservice-cli` on remote IBM i host.

This changes the API for transports slightly to pass information without having to use Toolkit-wide options, which seemed inappropriate to me. The API remains compatible with the old signature. This works for trivial things, but I don't know if this is the best solution.

Fixes #134 