### PR TITLE
Update the information about discussions board

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The PHP Toolkit for IBM i (Toolkit) is a PHP-based front end to [XMLSERVICE](htt
 
 The Toolkit is open source and has been developed with help from Alan Seiden and the community. 
 
+Discussion of the Toolkit takes place in GitHub Discussions:
+https://github.com/zendtech/IbmiToolkit/discussions
+
 Current Main Features:
 
 - Ability to call RPG, CL, and COBOL

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ The PHP Toolkit for IBM i (Toolkit) is a PHP-based front end to [XMLSERVICE](htt
 
 The Toolkit is open source and has been developed with help from Alan Seiden and the community. 
 
-Discussion of the Toolkit (usage and how to contribute) happens at the ‘Club Seiden’ forum:
-http://club.alanseiden.com/community/
-
 Current Main Features:
 
 - Ability to call RPG, CL, and COBOL


### PR DESCRIPTION
The board behind has been filled with off-topic materials before and now it is not accessible at all. Perhaps we should consider using GitHub Discussions feature instead?