### PR TITLE
Workaround optional args for API that presents mandatory arg first

### DIFF
--- a/ToolkitApi/ToolkitServiceXML.php
+++ b/ToolkitApi/ToolkitServiceXML.php
@@ -361,13 +361,16 @@ class XMLWrapper
      * 
      * @param string|array $inputOutputParams
      * @param array $returnParams
-     * @param $pgm
+     * @param $pgm Not actually optional, but should be the first option. This
+     *        is only optional before the first two arguments can be, but the
+     *        API was already made and we don't want to break backwards
+     *        compatibility. Consider this a warning to call this correctly.
      * @param string $lib blank library means use current/default or library list
      * @param null $function
      * @return string
      */
-    public function buildXmlIn($inputOutputParams, array $returnParams,
-                    $pgm,
+    public function buildXmlIn($inputOutputParams = NULL, array $returnParams = NULL,
+                    $pgm = "",
                     $lib = "",
                     $function = NULL)
     {


### PR DESCRIPTION
This API should really put $pgm first if it's semantically
required, but it puts some optional arguments before it. As such,
make them all optional with a warning in place that $pgm is really
not actually.

See https://github.com/zendtech/IbmiToolkit/commit/3e5377ea605abb3782ce257fb6f2f41b38a929ac#commitcomment-47897314