### PR TITLE
Docbloc return type for ToolkitService::getInstance() incorrect

### DIFF
--- a/ToolkitApi/ToolkitService.php
+++ b/ToolkitApi/ToolkitService.php
@@ -18,7 +18,7 @@ class ToolkitService
      * @param string $password
      * @param string $transportType
      * @param bool|array $isPersistent
-     * @return bool|null
+     * @return Toolkit
      */
     static function getInstance($databaseNameOrResource = '*LOCAL', $userOrI5NamingFlag = '', $password = '', $transportType = '', $isPersistent = false)
     {


### PR DESCRIPTION
With IDE's like Visual Studio Code there are PHP language server plugins like "PHP Intelephense" that offer IntelliSense and error checking for type hinting.  The @return type in the getInstance() docblock indicates "bool|null" and all variables assigned to this return type will assume a 'bool' value.

Instantiating the variable:
$conn = \ToolkitService::getInstance($db, $userOrI5NamingFlag='0', $password='', $transportType='pdo');

Using the variable will highlight an error detected with varaible "$conn":
$conn->setOptions(['stateless'=>true]);

Error message:
Expected type 'object'. Found 'bool|null'.

Changing the @return type to "Toolkit" removes the error syntax highlighting from the IDE, and correctly interprets/inspects the functions that the variable uses.