### PR TITLE
i5_connect(): default host to 'localhost'

### DIFF
--- a/ToolkitApi/CW/cw.php
+++ b/ToolkitApi/CW/cw.php
@@ -158,7 +158,7 @@ function noError()
  * @param array $options
  * @return mixed
  */
-function i5_connect($host='localhost', $user='', $password='', $options=array())
+function i5_connect($host='', $user='', $password='', $options=array())
 {
     // Special warning. We do not support proprietary codepagefile.
     if (isset($options[I5_OPTIONS_CODEPAGEFILE])) {
@@ -292,6 +292,11 @@ function i5_connect($host='localhost', $user='', $password='', $options=array())
             $transportType = $iniTransportType;
         }
     }
+    
+    // accommodate ('', '', '') style of connection
+    if (!$host) {
+        $host = 'localhost';
+    }    
     
     // convert host to dbname
     $dbname = getConfigValue('hosts', $host);


### PR DESCRIPTION
Adopt a more reliable way to set 'localhost' as the default host if empty $host was specified in i5_connect(). Although the $host parameter of i5_connect() defaulted to 'localhost' in the argument list, this was not a reliable way to ensure 'localhost' for an empty host value. We saw this at a client who used ('', '', '', array(i5_libl...)) and got an error about an unknown host value.