### PR TITLE
Correct order of plug prefixes

### DIFF
--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -525,7 +525,7 @@ class Toolkit implements ToolkitInterface
         // if a plug name is passed in, it overrides plugPrefix and plugSize.
         if (isset($options['plug']) && $options['plug']) {
             // @todo enumerate plug prefixes centrally, tied to db extension name, at top of this class
-            $possiblePrefixes = array('iPLUG', 'iPLUGR');
+            $possiblePrefixes = array('iPLUGR', 'iPLUG');
             $options['plugSize'] = str_replace($possiblePrefixes, '', $options['plug']); // remove prefix to get size
             $options['plugPrefix'] = str_replace($options['plugSize'], '', $options['plug']); // remove size to get prefix
 


### PR DESCRIPTION
Previous order was flawed. iPLUGR would never be selected because iPLUG was part of iPLUGR and would match in str_replace(). Hence, the wrong stored procedure would be selected under certain conditions.