### PR TITLE
Add driver options

### DIFF
--- a/ToolkitApi/Db2supp.php
+++ b/ToolkitApi/Db2supp.php
@@ -37,10 +37,17 @@ class db2supp
         }
         
         if ($options) {
+            $driver_options = array();
+
+            // Test for existence of driver options
+            if (array_key_exists('driver_options', $options)) {
+                $driver_options = $options['driver_options'] ?: array();
+            }
+
             if ((isset($options['persistent'])) && $options['persistent']) {
-                $conn = db2_pconnect($database, $user, $password);
+                $conn = db2_pconnect($database, $user, $password, $driver_options);
             } else {
-                $conn = db2_connect($database, $user, $password);
+                $conn = db2_connect($database, $user, $password, $driver_options);
             }
             
             if (is_resource($conn)) {


### PR DESCRIPTION
Missing driver_options can switch existing QSQSRVR jobs from SYSTEM
naming to SQL naming, which causes trouble with unqualified calls
and executions.

Committer note: This is a cleaned up version of PR #109.

Closes #109