### PR TITLE
Updated #39: Use stateless flag from toolkit.ini it is present to override value in $_options array

### DIFF
--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -86,6 +86,7 @@ class Toolkit implements ToolkitInterface
                                 'sbmjobCommand'  => '', // optional complete override of SBMJOB command when new toolkit job is submitted
                                 'prestart'       => false,
                                 'stateless'      => false,
+                                'stateless_mode_default' => true, // add new stateless flag for toolkit (non CW)
                                 'performance'    => false, // whether to enable performance collection (not fully implemented)
                                 'idleTimeout'    => '', // created for Compat. Wrapper (CW)
                                 'cdata'          => true, // whether to ask XMLSERVICE to wrap its output in CDATA to protect reserved XML characters
@@ -181,7 +182,7 @@ class Toolkit implements ToolkitInterface
         }
 
         // Optional params. Don't specify if not given in INI.
-        $this->getOptionalParams('system', array('v5r4', 'ccsidBefore', 'ccsidAfter', 'useHex', 'paseCcsid', 'trace', 'dataStructureIntegrity',  'arrayIntegrity'));
+        $this->getOptionalParams('system', array('stateless_mode_default', 'v5r4', 'ccsidBefore', 'ccsidAfter', 'useHex', 'paseCcsid', 'trace', 'dataStructureIntegrity', 'arrayIntegrity'));
         $this->getOptionalParams('transport', array('httpTransportUrl', 'plugSize', 'xmlserviceCliPath'));
 
         // populate serviceParams with $transport, or get it from INI
@@ -1861,7 +1862,12 @@ class Toolkit implements ToolkitInterface
      */
     public function isStateless()
     {
-        return $this->getOption('stateless');
+        if ($this->getIsCw()){
+            return $this->getOption('stateless');
+        }
+        else{
+            return $this->getOption('stateless_mode_default');
+        }
     }
 
     /**

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -1858,16 +1858,13 @@ class Toolkit implements ToolkitInterface
     }
 
     /**
+     * See if stateless mode has been turned on. Affects both CW and not-CW.
+     *
      * @return bool|void
      */
     public function isStateless()
     {
-        if ($this->getIsCw()){
-            return $this->getOption('stateless');
-        }
-        else{
-            return $this->getOption('stateless_mode_default');
-        }
+        return $this->getOption('stateless');
     }
 
     /**

--- a/ToolkitApi/toolkit.ini
+++ b/ToolkitApi/toolkit.ini
@@ -59,8 +59,13 @@ dataStructureIntegrity = true
 ; For backward compatibility with pre-1.4.0, set to false.
 arrayIntegrity = true
 
-; CW only: stateless mode is default for i5_connect (though automatically overridden if private conns are used)
-stateless = true
+; CW stateless flag
+; stateless mode is default for i5_connect (though automatically overridden if private conns are used)
+stateless = false
+; Non-CW Stateless flag - default to true
+; This should be overridden if you require stateful connections
+; Set the default value of 'stateless' to true, for the regular toolkit (not CW).
+stateless_mode_default = true
 
 [transport]
 ; transport type allows configuration of transport from this INI. 

--- a/ToolkitApi/toolkit.ini
+++ b/ToolkitApi/toolkit.ini
@@ -59,13 +59,13 @@ dataStructureIntegrity = true
 ; For backward compatibility with pre-1.4.0, set to false.
 arrayIntegrity = true
 
-; CW stateless flag
+; CW stateless flag, true for compatibility
 ; stateless mode is default for i5_connect (though automatically overridden if private conns are used)
-stateless = false
-; Non-CW Stateless flag - default to true
+stateless = true
+; Non-CW Stateless flag - default to false to match original semantics
 ; This should be overridden if you require stateful connections
 ; Set the default value of 'stateless' to true, for the regular toolkit (not CW).
-stateless_mode_default = true
+stateless_mode_default = false
 
 [transport]
 ; transport type allows configuration of transport from this INI. 


### PR DESCRIPTION
See #39 for details, originally authored by @Scott-Cam and fixed per Alan's comments since original branch wasn't writeable