### PR TITLE
Don't assume numeric index

### DIFF
--- a/ToolkitApi/PdoSupp.php
+++ b/ToolkitApi/PdoSupp.php
@@ -148,8 +148,8 @@ final class PdoSupp
 
         if (!$bindArray['disconnect']) {
             foreach ($statement->fetchAll() as $result) {
-                $tmp = $result[0];
-
+                // get XML string from first and only array element, no matter whether key is associative or indexed (numeric)
+                $tmp = reset($result); 
                 if ($tmp) {
                     // because of ODBC problem blob transferring should execute some "clean" on returned data
                     if (strstr($tmp , "</script>")) {


### PR DESCRIPTION
$result[0] could fail with "Undefined array key 0" if the Pdo default fetch mode was associative. Using the reset() function returns the first column, the equivalent of index 0 or whatever the associative key might be. There is only one column to retrieve, so this should always work.  Resolves issue #184.