### PR TITLE
Proposal for solving bin2hex deprecation message

### DIFF
--- a/ToolkitApi/ToolkitServiceXML.php
+++ b/ToolkitApi/ToolkitServiceXML.php
@@ -124,7 +124,7 @@ class XMLWrapper
      */
     protected function encodeString($string) 
     {
-        if ($this->getOption('useHex')) {
+        if ($this->getOption('useHex') && !empty($string) {
             return bin2hex($string);
         } else {
             return $string;

--- a/ToolkitApi/ToolkitServiceXML.php
+++ b/ToolkitApi/ToolkitServiceXML.php
@@ -124,7 +124,7 @@ class XMLWrapper
      */
     protected function encodeString($string) 
     {
-        if ($this->getOption('useHex') && !empty($string) {
+        if ($this->getOption('useHex') && !empty($string)) {
             return bin2hex($string);
         } else {
             return $string;


### PR DESCRIPTION
Proposal for solving:
bin2hex(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/zendtech/ibmitoolkit/ToolkitApi/ToolkitServiceXML.php on line 128