### PR TITLE
Update ODBC connection validation for PHP 8.4 compatibility

### DIFF
--- a/ToolkitApi/Odbcsupp.php
+++ b/ToolkitApi/Odbcsupp.php
@@ -37,7 +37,8 @@ class odbcsupp
                 $conn = odbc_connect($database, $user, $password);
             }
 
-            if (is_resource($conn)) {
+            if ((version_compare(PHP_VERSION, '8.4.0', '<') && is_resource($conn)) ||
+                (version_compare(PHP_VERSION, '8.4.0', '>=') && $conn instanceof \Odbc\Connection)) {
                 return $conn;
             }
         }
@@ -51,7 +52,8 @@ class odbcsupp
      */
     public function disconnect($conn)
     {
-        if (is_resource($conn)) {
+        if ((version_compare(PHP_VERSION, '8.4.0', '<') && is_resource($conn)) ||
+            (version_compare(PHP_VERSION, '8.4.0', '>=') && $conn instanceof \Odbc\Connection)) {
             odbc_close($conn);
         }
     }
@@ -168,7 +170,8 @@ class odbcsupp
         $txt = array();
         $crsr = odbc_exec($conn, $stmt);
         
-        if (is_resource($crsr)) {      
+        if ((version_compare(PHP_VERSION, '8.4.0', '<') && is_resource($crsr)) ||
+            (version_compare(PHP_VERSION, '8.4.0', '>=') && $crsr instanceof \Odbc\Result)) {     
             while (odbc_fetch_row($crsr)) {  
                 $row = odbc_result($crsr, 1);
                 

--- a/ToolkitApi/Toolkit.php
+++ b/ToolkitApi/Toolkit.php
@@ -285,7 +285,8 @@ class Toolkit implements ToolkitInterface
                 $this->debugLog("Created a new db connection in $durationCreate seconds.");
             }
 
-            if (!$conn) {
+            if ((version_compare(PHP_VERSION, '8.4.0', '<') && !is_resource($conn)) ||
+                (version_compare(PHP_VERSION, '8.4.0', '>=') && !($conn instanceof \Odbc\Connection))) {
                 // Note: SQLState 08001 (with or without SQLCODE=-30082) usually means invalid user or password. This is true for DB2 and ODBC.
                 $sqlState = $transport->getErrorCode();
                 $this->error = $transport->getErrorMsg();


### PR DESCRIPTION
**Summary of Changes**:
Updated validation to handle the `Odbc\Connection` and `Odbc\Result` return types introduced in PHP 8.4. For PHP 8.4 and above, checks are now made for `Odbc\Connection` (from `odbc_connect()`) and `Odbc\Result` (from `odbc_exec()`). Retained support for PHP 8.3 and earlier, which use resource-based return types.

**Why This Change**:
Ensures proper handling of ODBC connections and executions across PHP versions prior to 8.4, as well as 8.4 and above.

**Testing**:
Verified functionality on PHP 8.3 and 8.4 locally with successful results. The changes were tested primarily in the `connect()` function in `Odbcsupp.php` and the `__construct` method in `Toolkit.php`. Did not test the `executeQuery()` and `disconnect()` functions in `Odbcsupp.php`, as they are not used in my projects.
