### PR TITLE
Bump minimum PHP version to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-      "php": ">=5.3.3",
+      "php": ">=7.1",
       "ext-mbstring": "*",
       "ext-pcre": "*",
       "ext-pdo": "*",


### PR DESCRIPTION
I think this one is also relevant.

This pull request bumps the minimum required PHP version to 7.1 in the composer.json file. The reason for this change is that https://github.com/zendtech/IbmiToolkit/pull/218 commit introduced Nullable types and Class constant visibility modifiers, which are features available in PHP 7.1 and later versions.

By updating the minimum PHP version, we prevent potential installation issues for users who are still using older PHP versions. See also the release notes for PHP 7.1: https://www.php.net/releases/7_1_0.php